### PR TITLE
Move apply_psf and apply_exposure options to SpatialModel block

### DIFF
--- a/src/SourceFactory.cxx
+++ b/src/SourceFactory.cxx
@@ -261,6 +261,20 @@ void SourceFactory::makeSources(const std::string& xmlFile,
 	   src = makeDiffuseSource(spectrum, spatialModel, funcFactory,
 				   loadMaps);
 	 }
+	 /// Determine if psf can be applied.
+	 std::string apply_psf(xmlBase::Dom::getAttribute(spatialModel, "apply_psf"));
+	 if (apply_psf != "true" && apply_psf != "false" && apply_psf != "") {
+	   throw std::runtime_error("Invalid value for apply_psf attribute in xml definition of " + src->getName());
+	 }
+	 src->set_psf_flag(apply_psf != "false");
+
+	 /// Determine if exposure can be applied.
+	 std::string apply_exposure(xmlBase::Dom::getAttribute(spatialModel, "apply_exposure"));
+	 if (apply_exposure != "true" && apply_exposure != "false" && apply_exposure != "") {
+	   throw std::runtime_error("Invalid value for apply_exposure attribute in xml definition of " + src->getName());
+	 }
+	 src->set_exposure_flag(apply_exposure != "false");
+
       }
 
       if (src != 0) {
@@ -460,20 +474,6 @@ void SourceFactory::setSpectrum(Source * src, const DOMElement * spectrum,
       throw std::runtime_error("Invalid value for apply_edisp attribute in xml definition of " + src->getName());
    }
    src->set_edisp_flag(apply_edisp != "false");
-
-   /// Determine if psf can be applied.
-   std::string apply_psf(xmlBase::Dom::getAttribute(spectrum, "apply_psf"));
-   if (apply_psf != "true" && apply_psf != "false" && apply_psf != "") {
-      throw std::runtime_error("Invalid value for apply_psf attribute in xml definition of " + src->getName());
-   }
-   src->set_psf_flag(apply_psf != "false");
-
-   /// Determine if exposure can be applied.
-   std::string apply_exposure(xmlBase::Dom::getAttribute(spectrum, "apply_exposure"));
-   if (apply_exposure != "true" && apply_exposure != "false" && apply_exposure != "") {
-      throw std::runtime_error("Invalid value for apply_exposure attribute in xml definition of " + src->getName());
-   }
-   src->set_exposure_flag(apply_exposure != "false");
 
    delete spec;
 }


### PR DESCRIPTION
Minor adjustment to put the requested xml options in the spatialModel block instead of the spectral block.