### PR TITLE
Fix ModelMap to be much more efficient in writing files

### DIFF
--- a/Likelihood/ModelMap.h
+++ b/Likelihood/ModelMap.h
@@ -45,14 +45,6 @@ protected:
    void writeOutputMap_healpix(const std::string & outfile,
 			       const CountsMapHealpix& cmap,
 			       std::string outtype="CMAP");
-  
-   void trimExtensions_wcs(const std::string & outfile,
-			   const std::string & outtype="CMAP");
-
-   void trimExtensions_healpix(const std::string & outfile,
-			       const std::string & outtype="CMAP");
-
-
 
 private:
 

--- a/src/ModelMap.cxx
+++ b/src/ModelMap.cxx
@@ -7,6 +7,7 @@
 #include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <ctime>
 
 #include "fitsio.h"
 
@@ -119,9 +120,13 @@ void ModelMap::writeOutputMap_healpix(const std::string & outfile,
 }
 
 
+
 void ModelMap::writeOutputMap_wcs(const std::string & outfile,
-				  const CountsMap& cmap,
-				  std::string outtype) {
+				      const CountsMap& cmap,
+				      std::string outtype) {
+ 
+   std::clock_t start = std::clock();
+   
    ::toUpper(outtype);
    if (outtype != "CMAP" && outtype != "CCUBE") {
       std::ostringstream message;
@@ -130,6 +135,7 @@ void ModelMap::writeOutputMap_wcs(const std::string & outfile,
               << "Only 'CMAP' and 'CCUBE' are allowed.";
       throw std::runtime_error(message.str());
    }
+
    if (outtype == "CMAP") {
       // Sum up the image planes over the different energy bands.
       size_t image_size(cmap.imageDimension(0)*
@@ -142,80 +148,40 @@ void ModelMap::writeOutputMap_wcs(const std::string & outfile,
          }
       }
    }
+
+   cmap.writeOutput("gtmodel", outfile);
+
    std::string infile(cmap.filename());
-   bool clobber;
-   st_facilities::FitsUtil::fcopy(infile, outfile, "", "", clobber=true);
-   
+   const tip::Image * orig_image = tip::IFileSvc::instance().readImage(infile, "");
+   const tip::Header & orig_header = orig_image->getHeader();
+
    std::vector<long> new_dims;
-   const tip::Image * my_image = 
-      tip::IFileSvc::instance().readImage(outfile, "");
    typedef std::vector<tip::PixOrd_t> DimCont_t;
-   DimCont_t dims = my_image->getImageDimensions();
-   new_dims.push_back(dims.at(0));
-   new_dims.push_back(dims.at(1));
+   new_dims.push_back(cmap.naxis1());
+   new_dims.push_back(cmap.naxis2());
    if (outtype == "CCUBE") {
-      new_dims.push_back(dims.at(2));
+      new_dims.push_back(cmap.num_ebins());
    }
-   delete my_image;
+
    ::fitsResizeImage(outfile, -32, new_dims.size(), new_dims);
 
-   std::auto_ptr<tip::Image>
-      output_image(tip::IFileSvc::instance().editImage(outfile, ""));
+   std::auto_ptr<tip::Image> output_image(tip::IFileSvc::instance().editImage(outfile, ""));
+   tip::Header & output_header = output_image->getHeader();
    output_image->set(m_outmap);
-   dataSubselector::Cuts my_cuts(infile, "", false);
-   my_cuts.writeGtiExtension(outfile);
-   trimExtensions_wcs(outfile, outtype);
-}
-
-
-
-void ModelMap::trimExtensions_wcs(const std::string & outfile,
-				  const std::string & outtype) {
-   tip::FileSummary hdus;
-   tip::IFileSvc::instance().getFileSummary(outfile, hdus);
-   size_t nhdus = hdus.size();
-   fitsfile * fptr;
-   int status(0), hdutype;
-   fits_open_file(&fptr, outfile.c_str(), READWRITE, &status);
-   ::fitsReportError(stderr, status);
-   for (size_t i = 1; i < nhdus; i++) {
-      std::string hduname = hdus.at(i).getExtId();
-      if (hduname != "GTI" && (hduname != "EBOUNDS" || outtype == "CMAP")) {
-         fits_movnam_hdu(fptr, ANY_HDU, const_cast<char *>(hduname.c_str()), 
-                         0, &status);
-         ::fitsReportError(stderr, status);
-         fits_delete_hdu(fptr, &hdutype, &status);
-         ::fitsReportError(stderr, status);
-      }
+   
+   for ( tip::Header::ConstIterator itr = orig_header.begin(); itr != orig_header.end(); itr++ ) {
+     output_header.append(*itr);
    }
+
    if (outtype == "CMAP") {
-// Delete axis 3 keywords in PRIMARY HDU.
-      fits_movabs_hdu(fptr, 1, &hdutype, &status);
-      ::fitsReportError(stderr, status);
-
-      fits_delete_key(fptr, "CTYPE3", &status);
-      ::fitsReportError(stderr, status);
-      fits_delete_key(fptr, "CRPIX3", &status);
-      ::fitsReportError(stderr, status);
-      fits_delete_key(fptr, "CRVAL3", &status);
-      ::fitsReportError(stderr, status);
-      fits_delete_key(fptr, "CDELT3", &status);
-      ::fitsReportError(stderr, status);
-      fits_delete_key(fptr, "CUNIT3", &status);
-      ::fitsReportError(stderr, status);
+     output_header.erase("CTYPE3");
+     output_header.erase("CRPIX3");
+     output_header.erase("CRVAL3");
+     output_header.erase("CDELT3");
+     output_header.erase("CUNIT3");
    }
 
-// Update creator keyword.
-   char * keyname = const_cast<char *>("CREATOR");
-   char * creator = const_cast<char *>("gtmodel");
-   char * description = const_cast<char *>("Software creating file");
-   fits_update_key(fptr, TSTRING, keyname, creator, description, &status);
-   ::fitsReportError(stderr, status);
-
-   fits_close_file(fptr, &status);
-   ::fitsReportError(stderr, status);
-
-   st_facilities::FitsUtil::writeChecksums(outfile);
 }
+
 
 } // namespace Likelihood


### PR DESCRIPTION
The class ModelMap only existing to write model maps.   Because of horrific inefficiencies in how it was using tip it was taking 20 minutes to write the model map file.  (Actually it was copying the source map file, then taking 20 minutes to sequentially delete each of the source map HDUs).

The PR fixes that.   Now the same job takes about 30 seconds.

-e