### PR TITLE
Put BinnedLikelihood::use_edisp() method back in

### DIFF
--- a/Likelihood/BinnedLikelihood.h
+++ b/Likelihood/BinnedLikelihood.h
@@ -613,6 +613,12 @@ namespace Likelihood {
      /* Return flag saying how we use energy dispersion for a particular source */
      int edisp_val(const std::string & srcname="") const;
 
+     /* Return flag saying if we are using energy dispersion of a particular source */
+     bool use_edisp(const std::string & srcname="") const {
+       int v = edisp_val(srcname);
+       return ( v >= 0 );
+     }
+
      /* Return the DRM (detector response matrix), building it if needed */
      Drm & drm();
 


### PR DESCRIPTION
This just puts the method  bool use_edisp() back into BinnedLikelihood.   It was replaced by int edisp_val().

use_edisp returns true if edisp_val >= 0.