### PR TITLE
Param check update

### DIFF
--- a/Likelihood/AppHelpers.h
+++ b/Likelihood/AppHelpers.h
@@ -107,7 +107,7 @@ public:
 
    template<typename T>
    static T param(st_app::AppParGroup & pars, const std::string & parname,
-                  const T & def_value, const bool & suppress_warn);
+                  const T & def_value, const bool & suppress_warn = false);
 
    static void checkOutputFile(bool clobber, const std::string & filename);
 
@@ -238,7 +238,7 @@ protected:
 
 template<typename T>
 T AppHelpers::param(st_app::AppParGroup & pars, const std::string & parname,
-                    const T & def_value, const bool & suppress_warn) {
+                    const T & def_value, const bool & suppress_warn = false) {
    try {
       T value = pars[parname];
       return value;

--- a/Likelihood/AppHelpers.h
+++ b/Likelihood/AppHelpers.h
@@ -107,7 +107,7 @@ public:
 
    template<typename T>
    static T param(st_app::AppParGroup & pars, const std::string & parname,
-                  const T & def_value, const bool & suppress_warn = false);
+                  const T & def_value, const bool & suppress_warn);
 
    static void checkOutputFile(bool clobber, const std::string & filename);
 

--- a/Likelihood/AppHelpers.h
+++ b/Likelihood/AppHelpers.h
@@ -107,7 +107,7 @@ public:
 
    template<typename T>
    static T param(st_app::AppParGroup & pars, const std::string & parname,
-                  const T & def_value);
+                  const T & def_value, const bool & suppress_warn);
 
    static void checkOutputFile(bool clobber, const std::string & filename);
 
@@ -238,14 +238,16 @@ protected:
 
 template<typename T>
 T AppHelpers::param(st_app::AppParGroup & pars, const std::string & parname,
-                    const T & def_value) {
+                    const T & def_value, const bool & suppress_warn) {
    try {
       T value = pars[parname];
       return value;
    } catch (std::exception & eObj) {
+     if (suppress_warn == False) {
       std::cerr << eObj.what() << "\n"
                 << "Using default value of " << def_value
                 << " for parameter " <<  parname << std::endl;
+     }
       return def_value;
    }
 }

--- a/Likelihood/AppHelpers.h
+++ b/Likelihood/AppHelpers.h
@@ -107,7 +107,7 @@ public:
 
    template<typename T>
    static T param(st_app::AppParGroup & pars, const std::string & parname,
-                  const T & def_value, const bool & suppress_warn);
+                  const T & def_value, const bool & suppress_warn = false);
 
    static void checkOutputFile(bool clobber, const std::string & filename);
 
@@ -238,7 +238,7 @@ protected:
 
 template<typename T>
 T AppHelpers::param(st_app::AppParGroup & pars, const std::string & parname,
-                    const T & def_value, const bool & suppress_warn = false) {
+                    const T & def_value, const bool & suppress_warn) {
    try {
       T value = pars[parname];
       return value;

--- a/Likelihood/AppHelpers.h
+++ b/Likelihood/AppHelpers.h
@@ -243,7 +243,7 @@ T AppHelpers::param(st_app::AppParGroup & pars, const std::string & parname,
       T value = pars[parname];
       return value;
    } catch (std::exception & eObj) {
-     if (suppress_warn == False) {
+     if (suppress_warn == false) {
       std::cerr << eObj.what() << "\n"
                 << "Using default value of " << def_value
                 << " for parameter " <<  parname << std::endl;

--- a/src/AppHelpers.cxx
+++ b/src/AppHelpers.cxx
@@ -176,7 +176,7 @@ AppHelpers::AppHelpers(st_app::AppParGroup * pars,
 	 // EAC, build a map to get the ref-dir and energies
 	 // EAC, it might be better to write a function just to pull those out 
 	 CountsMapBase* cmap = readCountsMap(cmapfile);
-	 int edisp_bins = AppHelpers::param(my_pars, "edisp_bins", 0, False);
+	 int edisp_bins = AppHelpers::param(my_pars, "edisp_bins", 0, false);
 	 if ( edisp_bins < 0 ) {
 	   edisp_bins = 0;
 	 }

--- a/src/AppHelpers.cxx
+++ b/src/AppHelpers.cxx
@@ -176,7 +176,7 @@ AppHelpers::AppHelpers(st_app::AppParGroup * pars,
 	 // EAC, build a map to get the ref-dir and energies
 	 // EAC, it might be better to write a function just to pull those out 
 	 CountsMapBase* cmap = readCountsMap(cmapfile);
-	 int edisp_bins = AppHelpers::param(my_pars, "edisp_bins", 0, false);
+	 int edisp_bins = AppHelpers::param(my_pars, "edisp_bins", 0, true);
 	 if ( edisp_bins < 0 ) {
 	   edisp_bins = 0;
 	 }

--- a/src/AppHelpers.cxx
+++ b/src/AppHelpers.cxx
@@ -176,7 +176,7 @@ AppHelpers::AppHelpers(st_app::AppParGroup * pars,
 	 // EAC, build a map to get the ref-dir and energies
 	 // EAC, it might be better to write a function just to pull those out 
 	 CountsMapBase* cmap = readCountsMap(cmapfile);
-	 int edisp_bins = AppHelpers::param(my_pars, "edisp_bins", 0);
+	 int edisp_bins = AppHelpers::param(my_pars, "edisp_bins", 0, False);
 	 if ( edisp_bins < 0 ) {
 	   edisp_bins = 0;
 	 }
@@ -1088,7 +1088,7 @@ BinnedLikelihood* AppHelpers::makeBinnedLikelihood(st_app::AppParGroup& pars,
 
   ProjMap* wmap(0);
   static const std::string noneString("none");
-  std::string wmap_file = AppHelpers::param(pars, "wmap", noneString);
+  std::string wmap_file = AppHelpers::param(pars, "wmap", noneString, true);
     
   if ( wmap_file != noneString ) {
     wmap = WcsMapLibrary::instance()->wcsmap(wmap_file,"");

--- a/src/AppHelpers.cxx
+++ b/src/AppHelpers.cxx
@@ -1072,14 +1072,14 @@ BinnedLikelihood* AppHelpers::makeBinnedLikelihood(st_app::AppParGroup& pars,
   CountsMapBase* dataMap = AppHelpers::readCountsMap(cmap);
   AppHelpers::checkExposureMap(cmap, bexpmap);
 
-  bool computePointSources = AppHelpers::param(pars, "ptsrc", true);
-  bool psf_corrections = AppHelpers::param(pars, "psfcorr", true);
-  bool perform_convolution = AppHelpers::param(pars, "convol", true);  
-  bool resample = AppHelpers::param(pars, "resample", true);
-  int resamp_factor = AppHelpers::param(pars, "rfactor", 2);
-  double minbinsz = AppHelpers::param(pars, "minbinsz", 0.1);
+  bool computePointSources = AppHelpers::param(pars, "ptsrc", true, true);
+  bool psf_corrections = AppHelpers::param(pars, "psfcorr", true, true);
+  bool perform_convolution = AppHelpers::param(pars, "convol", true, true);  
+  bool resample = AppHelpers::param(pars, "resample", true, true);
+  int resamp_factor = AppHelpers::param(pars, "rfactor", 2, true);
+  double minbinsz = AppHelpers::param(pars, "minbinsz", 0.1, true);
   
-  int edisp_val = AppHelpers::param(pars, "edisp_bins", 0);
+  int edisp_val = AppHelpers::param(pars, "edisp_bins", 0, true);
 
   BinnedLikeConfig config(computePointSources, psf_corrections, 
 			  perform_convolution, resample, resamp_factor, 


### PR DESCRIPTION
Add suppress warning option to AppHelper param function to suppress unnecessary binned likelihood param warnings