### PR TITLE
Root6

### DIFF
--- a/src/AppHelpers.cxx
+++ b/src/AppHelpers.cxx
@@ -15,7 +15,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <vector>
-// EAC, added for std::auto_ptr
+// EAC, added for std::unique_ptr
 #include <memory> 
 
 #include "st_stream/StreamFormatter.h"
@@ -968,7 +968,7 @@ astro::ProjBase::Method
 AppHelpers::checkProjectionMethod(const std::string& filename,
                                   const std::string& hpx_ext) {  
   // Try the primary header first
-  std::auto_ptr<const tip::Image> primary(tip::IFileSvc::instance().readImage(filename,std::string("")));
+  std::unique_ptr<const tip::Image> primary(tip::IFileSvc::instance().readImage(filename,std::string("")));
   const tip::Header& header = primary->getHeader();
   int naxis(0);
   try {
@@ -985,7 +985,7 @@ AppHelpers::checkProjectionMethod(const std::string& filename,
   const std::string ext_name = hpx_ext.empty() ? "SKYMAP" : hpx_ext;
 
   // Try the extension header
-  std::auto_ptr<const tip::Extension> ext(tip::IFileSvc::instance().readExtension(filename,ext_name));
+  std::unique_ptr<const tip::Extension> ext(tip::IFileSvc::instance().readExtension(filename,ext_name));
   const tip::Header& header_ext = ext->getHeader();
   if ( ext->isTable() ) {
     std::string pixtype;

--- a/src/BinnedExposure.cxx
+++ b/src/BinnedExposure.cxx
@@ -74,7 +74,7 @@ BinnedExposure::BinnedExposure(const std::string & filename)
 
    m_proj = new astro::SkyProj(filename);
 
-   std::auto_ptr<const tip::Image> 
+   std::unique_ptr<const tip::Image> 
       image(tip::IFileSvc::instance().readImage(filename, ""));
 
    m_exposureMap.clear();

--- a/src/BinnedExposureBase.cxx
+++ b/src/BinnedExposureBase.cxx
@@ -86,7 +86,7 @@ BinnedExposureBase::BinnedExposureBase(const std::string & filename)
    : m_observation(0), m_proj(0), m_costhmin(-1), m_costhmax(1),
      m_enforce_boundaries(false),m_allSky(false) {
 
-   std::auto_ptr<const tip::Table>
+   std::unique_ptr<const tip::Table>
     energies(tip::IFileSvc::instance().readTable(filename, "Energies"));
 
    m_energies.clear();

--- a/src/BinnedHealpixExposure.cxx
+++ b/src/BinnedHealpixExposure.cxx
@@ -81,7 +81,7 @@ BinnedHealpixExposure::BinnedHealpixExposure(const std::string& filename)
     m_healpixProj(new astro::HealpixProj(filename,std::string("HPXEXPOSURES"))){
   setMapGeometry();
 
-  std::auto_ptr<const tip::Table> 
+  std::unique_ptr<const tip::Table> 
     table(tip::IFileSvc::instance().readTable(filename, std::string("HPXEXPOSURES")));
   
   // This is a bit tricky, basically all the data we care about

--- a/src/Convolve.cxx
+++ b/src/Convolve.cxx
@@ -11,7 +11,11 @@
 #include <stdexcept>
 #include <vector>
 
+#ifndef CONDA_FFTW
 #include "fftw/fftw3.h"
+#else
+#include "fftw3.h"
+#endif
 
 #include "Likelihood/Convolve.h"
 

--- a/src/CountsMap.cxx
+++ b/src/CountsMap.cxx
@@ -289,7 +289,7 @@ CountsMapBase* CountsMap::makeBkgEffMap(const MeanPsf & psf, const float& efact)
 void CountsMap::readImageData(const std::string & countsMapFile,
                               std::vector<evtbin::Binner *> & binners) {
    m_hist = new HistND(binners);
-   std::auto_ptr<const tip::Image> 
+   std::unique_ptr<const tip::Image> 
       image(tip::IFileSvc::instance().readImage(countsMapFile, ""));
    std::vector<float> image_data;
    image->get(image_data);
@@ -297,7 +297,7 @@ void CountsMap::readImageData(const std::string & countsMapFile,
 }
 
 void CountsMap::readKeywords(const std::string & countsMapFile) {
-   std::auto_ptr<const tip::Image> 
+   std::unique_ptr<const tip::Image> 
       image(tip::IFileSvc::instance().readImage(countsMapFile, ""));
    const tip::Header & header = image->getHeader();
    typedef std::vector<tip::PixOrd_t> DimCont_t;

--- a/src/CountsMapHealpix.cxx
+++ b/src/CountsMapHealpix.cxx
@@ -301,7 +301,7 @@ void CountsMapHealpix::readImageData(const std::string & countsMapFile,
 				     std::vector<evtbin::Binner *> & binners) {
   m_hist = new HistND(binners);
   static const std::string extName("SKYMAP");
-  std::auto_ptr<const tip::Table> 
+  std::unique_ptr<const tip::Table> 
     table(tip::IFileSvc::instance().readTable(countsMapFile,extName));
 
   // This is a bit tricky, basically all the data we care about

--- a/src/ExposureMap.cxx
+++ b/src/ExposureMap.cxx
@@ -278,7 +278,7 @@ void ExposureMap::writeFitsFile(const std::string & filename,
 
 void ExposureMap::readEnergyExtension(const std::string & filename,
                                       std::vector<double> & energies) {
-   std::auto_ptr<const tip::Table> 
+   std::unique_ptr<const tip::Table> 
       table(tip::IFileSvc::instance().readTable(filename, "ENERGIES"));
    energies.resize(table->getNumRecords());
 

--- a/src/FileUtils.cxx
+++ b/src/FileUtils.cxx
@@ -48,7 +48,7 @@ namespace Likelihood {
     bool fileHasExtension(const std::string& filename, 
 			  const std::string& extension) {
       try {
-	std::auto_ptr<const tip::Extension> ext(tip::IFileSvc::instance().readExtension(filename,extension));
+	std::unique_ptr<const tip::Extension> ext(tip::IFileSvc::instance().readExtension(filename,extension));
       } catch (tip::TipException &) {
 	return false;
       }
@@ -59,7 +59,7 @@ namespace Likelihood {
     void read_ebounds_to_vector(const std::string& filename,
 				std::vector<double>& energies) {
       
-      std::auto_ptr<const tip::Table> ebounds(tip::IFileSvc::instance().readTable(filename, "EBOUNDS"));
+      std::unique_ptr<const tip::Table> ebounds(tip::IFileSvc::instance().readTable(filename, "EBOUNDS"));
       tip::Table::ConstIterator it = ebounds->begin();
       tip::Table::ConstRecord & row = *it;
       energies.clear();
@@ -77,7 +77,7 @@ namespace Likelihood {
 					const std::string& extension ,
 					std::vector<float>& vect,
 					int& nEvals) {
-      std::auto_ptr<const tip::Image>
+      std::unique_ptr<const tip::Image>
 	image(tip::IFileSvc::instance().readImage(filename,extension));
       const tip::Header& header = image->getHeader();
       header["NAXIS3"].get(nEvals);
@@ -90,7 +90,7 @@ namespace Likelihood {
 					   const std::string& extension,
 					   std::vector<float>& vect,
 					   int& nEvals) {
-      std::auto_ptr<const tip::Table> 
+      std::unique_ptr<const tip::Table> 
 	table(tip::IFileSvc::instance().readTable(filename,extension));
       
       // This is a bit tricky, basically all the data we care about
@@ -131,7 +131,7 @@ namespace Likelihood {
 					    SparseVector<float>& vect,
 					    int& nEvals) {
       vect.clear_data();
-      std::auto_ptr<const tip::Table> 
+      std::unique_ptr<const tip::Table> 
 	table(tip::IFileSvc::instance().readTable(filename,extension));
 
       const tip::Header& header = table->getHeader();
@@ -192,7 +192,7 @@ namespace Likelihood {
 				const std::string& extension) {
 
       try {
-	std::auto_ptr<const tip::Image>
+	std::unique_ptr<const tip::Image>
 	image(tip::IFileSvc::instance().readImage(filename,extension));
 	// It's a WCS Image
 	return FileUtils::WCS;
@@ -200,7 +200,7 @@ namespace Likelihood {
 	;
       }
 
-      std::auto_ptr<const tip::Table> 
+      std::unique_ptr<const tip::Table> 
 	table(tip::IFileSvc::instance().readTable(filename,extension));
 
       const tip::Header& header = table->getHeader();     
@@ -745,7 +745,7 @@ namespace Likelihood {
     void read_parameters_from_table(const std::string& file_name,
 				    const std::string& table_name,
 				    SourceModel& srcModel) {
-      std::auto_ptr<const tip::Table> 
+      std::unique_ptr<const tip::Table> 
 	table(tip::IFileSvc::instance().readTable(file_name,table_name));
       
       const tip::IColumn& src_name_col = get_column(*table,"SourceName");
@@ -793,7 +793,7 @@ namespace Likelihood {
       long app_num_elem = drm.nmeas();
 
       // Open ebounds table for writing.
-      std::auto_ptr<tip::Table> ebounds(tip::IFileSvc::instance().editTable(file_name, "EBOUNDS"));      
+      std::unique_ptr<tip::Table> ebounds(tip::IFileSvc::instance().editTable(file_name, "EBOUNDS"));      
       // Set detchans explicitly.
       ebounds->getHeader()["DETCHANS"].set(app_num_elem);
 
@@ -843,7 +843,7 @@ namespace Likelihood {
     Drm* read_drm_from_table(const std::string& file_name,
 			     const std::string& table_name) {
 
-      std::auto_ptr<const tip::Table> 
+      std::unique_ptr<const tip::Table> 
 	table(tip::IFileSvc::instance().readTable(file_name,table_name));
 
       const tip::Header& header = table->getHeader();

--- a/src/FitScanner.cxx
+++ b/src/FitScanner.cxx
@@ -428,9 +428,9 @@ namespace Likelihood {
   }
   
   int FitScanModelWrapper::writeFits_EnergyBins(const std::string& fitsFile) const {
-    // Open EBOUNDS extension of output PHA1 file. Use an auto_ptr so that the table object
+    // Open EBOUNDS extension of output PHA1 file. Use an unique_ptr so that the table object
     // will for sure be deleted, even if an exception is thrown.
-    std::auto_ptr<tip::Table> output_table(tip::IFileSvc::instance().editTable(fitsFile, "EBOUNDS"));
+    std::unique_ptr<tip::Table> output_table(tip::IFileSvc::instance().editTable(fitsFile, "EBOUNDS"));
 
     // Resize table: number of records in output file must == the number of bins in the binner.
     output_table->setNumRecords(nEBins());
@@ -453,7 +453,7 @@ namespace Likelihood {
   
   int FitScanModelWrapper::writeFits_FluxTable(const std::string& fitsFile) const {
 
-    std::auto_ptr<tip::Table> output_table(tip::IFileSvc::instance().editTable(fitsFile, "EBOUNDS"));
+    std::unique_ptr<tip::Table> output_table(tip::IFileSvc::instance().editTable(fitsFile, "EBOUNDS"));
 
     static const std::string ref_energy_name("E_REF");
     static const std::string ref_dnde_name("REF_DNDE");
@@ -3312,11 +3312,11 @@ namespace Likelihood {
     if ( m_baselinePars.num_row() == 0 ) {
       return 0;
     }
-    // Open BASELINE extension of output file. Use an auto_ptr so that the table object
+    // Open BASELINE extension of output file. Use an unique_ptr so that the table object
     // will for sure be deleted, even if an exception is thrown.
 
     static const std::string baseline("BASELINE");
-    std::auto_ptr<tip::Table> table(tip::IFileSvc::instance().editTable(fitsFile,baseline));
+    std::unique_ptr<tip::Table> table(tip::IFileSvc::instance().editTable(fitsFile,baseline));
 
     // Resize table: number of records in output file must == the number of bins in the binner.
     table->setNumRecords(1);

--- a/src/ModelMap.cxx
+++ b/src/ModelMap.cxx
@@ -165,7 +165,7 @@ void ModelMap::writeOutputMap_wcs(const std::string & outfile,
 
    ::fitsResizeImage(outfile, -32, new_dims.size(), new_dims);
 
-   std::auto_ptr<tip::Image> output_image(tip::IFileSvc::instance().editImage(outfile, ""));
+   std::unique_ptr<tip::Image> output_image(tip::IFileSvc::instance().editImage(outfile, ""));
    tip::Header & output_header = output_image->getHeader();
    output_image->set(m_outmap);
    

--- a/src/SConstruct
+++ b/src/SConstruct
@@ -45,7 +45,7 @@ cflags = ' -DHAVE_OPT_PP -rdynamic -pg'
 #cflags = ' -DHAVE_OPT_PP -rdynamic '
 linkflags = '-pg'
 #linkflags = ' '
-rootlibs = ['Cint', 'Tree', 'Matrix', 'Physics', 
+rootlibs = ['Cling', 'Tree', 'Matrix', 'Physics', 
             'Hist', 'Graf', 'Graf3d', 'Gpad', 'Rint', 'Postscript', 'Gui']
 Export(['package', 'home', 'apps', 'libraries', 'cflags',
         'linkflags', 'rootlibs'])

--- a/src/backfile/backfile.cxx
+++ b/src/backfile/backfile.cxx
@@ -199,7 +199,7 @@ double BackFile::NpredError(const Likelihood::LogLike & logLike,
 void BackFile::getEbounds(std::vector<double> & emin,
                           std::vector<double> & emax) const {
    std::string pha_file = m_pars["phafile"];
-   std::auto_ptr<const tip::Table>
+   std::unique_ptr<const tip::Table>
       ebounds(tip::IFileSvc::instance().readTable(pha_file, "EBOUNDS"));
 
    long nenergies = ebounds->getNumRecords();
@@ -245,7 +245,7 @@ void BackFile::setHeaderKeyword(const std::string & phafile,
                                 const std::string & extension,
                                 const std::string & keyname,
                                 const std::string & value) const {
-   std::auto_ptr<tip::Table>
+   std::unique_ptr<tip::Table>
       spectrum(tip::IFileSvc::instance().editTable(phafile, extension));
    tip::Header & header = spectrum->getHeader();
    header[keyname].set(value);

--- a/src/diffuseResponses/diffuseResponses.cxx
+++ b/src/diffuseResponses/diffuseResponses.cxx
@@ -123,7 +123,7 @@ private:
    void checkColumnVersion(const std::string & evfile) const;
    void convert_header(const std::string & evfile) const;
    void readDiffuseNames(std::vector<std::string> & srcNames);
-   void readDiffRespNames(std::unique_ptr<const tip::Table> events,
+   void readDiffRespNames(std::unique_ptr<const tip::Table> const& events,
                           std::vector<std::string> & colnames);
    void readExistingDiffRespKeys(const tip::Table * events);
    bool haveDiffuseColumns(const std::string & eventFile);
@@ -301,7 +301,7 @@ bool diffuseResponses::haveDiffuseColumns(const std::string & eventFile) {
       events(tip::IFileSvc::instance().readTable(eventFile,
                                                  m_pars["evtable"]));
    std::vector<std::string> colNames;
-   readDiffRespNames(events, colNames);
+   readDiffRespNames(events, colNames); //
 
    std::vector<std::string> srcNames;
    readDiffuseNames(srcNames);
@@ -319,7 +319,7 @@ bool diffuseResponses::haveDiffuseColumns(const std::string & eventFile) {
 }
 
 void diffuseResponses::
-readDiffRespNames(std::unique_ptr<const tip::Table> events,
+readDiffRespNames(std::unique_ptr<const tip::Table> const& events,
                   std::vector<std::string> & colnames) {
 // Read in DIFRSPxx names (or column names if using old format)
    const tip::Header & header(events->getHeader());

--- a/src/diffuseResponses/diffuseResponses.cxx
+++ b/src/diffuseResponses/diffuseResponses.cxx
@@ -123,7 +123,7 @@ private:
    void checkColumnVersion(const std::string & evfile) const;
    void convert_header(const std::string & evfile) const;
    void readDiffuseNames(std::vector<std::string> & srcNames);
-   void readDiffRespNames(std::auto_ptr<const tip::Table> events,
+   void readDiffRespNames(std::unique_ptr<const tip::Table> events,
                           std::vector<std::string> & colnames);
    void readExistingDiffRespKeys(const tip::Table * events);
    bool haveDiffuseColumns(const std::string & eventFile);
@@ -255,7 +255,7 @@ void diffuseResponses::checkColumnVersion(const std::string & evfile) const {
 }
 
 void diffuseResponses::convert_header(const std::string & evfile) const {
-   std::auto_ptr<tip::Table> 
+   std::unique_ptr<tip::Table> 
       events(tip::IFileSvc::instance().editTable(evfile, m_pars["evtable"]));
    tip::Header & header(events->getHeader());
    const tip::Table::FieldCont & validFields(events->getValidFields());
@@ -297,7 +297,7 @@ void diffuseResponses::readDiffuseNames(std::vector<std::string> & srcNames) {
 }
 
 bool diffuseResponses::haveDiffuseColumns(const std::string & eventFile) {
-   std::auto_ptr<const tip::Table> 
+   std::unique_ptr<const tip::Table> 
       events(tip::IFileSvc::instance().readTable(eventFile,
                                                  m_pars["evtable"]));
    std::vector<std::string> colNames;
@@ -319,7 +319,7 @@ bool diffuseResponses::haveDiffuseColumns(const std::string & eventFile) {
 }
 
 void diffuseResponses::
-readDiffRespNames(std::auto_ptr<const tip::Table> events,
+readDiffRespNames(std::unique_ptr<const tip::Table> events,
                   std::vector<std::string> & colnames) {
 // Read in DIFRSPxx names (or column names if using old format)
    const tip::Header & header(events->getHeader());

--- a/src/gtcntsmap/gtcntsmap.cxx
+++ b/src/gtcntsmap/gtcntsmap.cxx
@@ -177,7 +177,7 @@ void gtcntsmap::promptForParameters() {
 
 void gtcntsmap::writeDssCuts() const {
    std::string output_file = m_pars["outfile"];
-   std::auto_ptr<tip::Image> 
+   std::unique_ptr<tip::Image> 
       image(tip::IFileSvc::instance().editImage(output_file, ""));
    m_cuts->writeDssKeywords(image->getHeader());
    m_cuts->writeGtiExtension(output_file);

--- a/src/gtsrcmaps/gtsrcmaps.cxx
+++ b/src/gtsrcmaps/gtsrcmaps.cxx
@@ -188,7 +188,7 @@ void gtsrcmaps::run() {
    m_binnedLikelihood->buildFixedModelWts(true);
    m_binnedLikelihood->saveSourceMaps(srcMapsFile);
 
-   std::auto_ptr<tip::Image>
+   std::unique_ptr<tip::Image>
       image(tip::IFileSvc::instance().editImage(srcMapsFile, ""));
    my_cuts.addVersionCut("IRF_VERSION", m_helper->irfsName());
    std::string irfs = m_pars["irfs"];
@@ -201,7 +201,7 @@ void gtsrcmaps::run() {
 
 void gtsrcmaps::getRefCoord(const std::string & countsMapFile, 
                             double & ra, double & dec) const {
-   std::auto_ptr<const tip::Image> 
+   std::unique_ptr<const tip::Image> 
       image(tip::IFileSvc::instance().readImage(countsMapFile, ""));
    const tip::Header & header = image->getHeader();
    std::string ctype;

--- a/src/likelihood/likelihood.cxx
+++ b/src/likelihood/likelihood.cxx
@@ -528,7 +528,7 @@ void likelihood::plotCountsSpectra() {
    try {
 // Create the main frame to hold all plot frames.
       st_graph::Engine & engine(st_graph::Engine::instance());
-      std::auto_ptr<st_graph::IFrame> 
+      std::unique_ptr<st_graph::IFrame> 
          mainFrame(engine.createMainFrame(0, 600, 600));
 // Create the plot.
       EasyPlot plot(mainFrame.get(), "", true, true, "Energy (MeV)", 

--- a/src/makeExposureCube/makeExposureCube.cxx
+++ b/src/makeExposureCube/makeExposureCube.cxx
@@ -130,7 +130,7 @@ void ExposureCube::run() {
 
 void ExposureCube::writeTableKeywords(const std::string & outfile,
                                       const std::string & tablename) const {
-   std::auto_ptr<tip::Table> 
+   std::unique_ptr<tip::Table> 
       table(tip::IFileSvc::instance().editTable(outfile, tablename));
    m_roiCuts->writeDssTimeKeywords(table->getHeader());
    double tstart(m_roiCuts->minTime());

--- a/src/meanPsf/meanPsf.cxx
+++ b/src/meanPsf/meanPsf.cxx
@@ -132,7 +132,7 @@ void meanPsf::writeFitsFile() {
    }
    std::remove(output_file.c_str());
    tip::IFileSvc::instance().appendTable(output_file, extension);
-   std::auto_ptr<tip::Table> 
+   std::unique_ptr<tip::Table> 
       psf_table(tip::IFileSvc::instance().editTable(output_file, extension));
    psf_table->appendField("Energy", "1D");
    psf_table->appendField("Exposure", "1D");
@@ -164,7 +164,7 @@ void meanPsf::writeFitsFile() {
 
    extension = "THETA";
    tip::IFileSvc::instance().appendTable(output_file, extension);
-   std::auto_ptr<tip::Table> 
+   std::unique_ptr<tip::Table> 
       theta_table(tip::IFileSvc::instance().editTable(output_file, extension));
    theta_table->appendField("Theta", "1D");
    theta_table->setNumRecords(m_thetas.size());


### PR DESCRIPTION
This is a PR to merge changes necessary for using root6 and modern compilers into Likelihood

Essentially the changes are to stop using the old CINT interpreter and to replace the use of the deprecated std::auto_ptr with the new and preferred std::unique_ptr.

See https://github.com/fermi-lat/Fermitools-conda/pull/67