### PR TITLE
add check for m_save_map and slight formatting fix

### DIFF
--- a/src/SourceMap.cxx
+++ b/src/SourceMap.cxx
@@ -374,17 +374,16 @@ void SourceMap::computeNpredArray_sparse() {
 
   void SourceMap::setSource(const Source& src) {
     if ( m_src == &src ) {
-      if ( m_model.size() == 0 &&
-	   m_sparseModel.size() == 0 ) {
-	if ( m_filename.size() > 0 ) {
-	  readModel(m_filename);
-	} else {
-	  set_energies();
-	  make_model();
-	  return;
-	}
+      if ( m_save_model && m_model.size() == 0 && m_sparseModel.size() == 0 ) {
+        if ( m_filename.size() > 0 ) {
+          readModel(m_filename);
+        } else {
+          set_energies();
+          make_model();
+          return;
+        }
       } else {
-	return;
+	    return;
       }
     }
     m_src = &src;


### PR DESCRIPTION
This adds a check against the m_save_map member variable in the SourceMap class setSource() method to properly prevent reloading of data for fixed map sources that are no longer needed.  This significantly reduces the memory used by the fitting (in the test harness it reduced the map memory allocated from 2.1 GB to 166 MB and total usage from 2.8 GB to 740 MB).

I also cleaned up the formatting of the if() statements just a bit.