### PR TITLE
Revert "add check for m_save_map and slight formatting fix"

### DIFF
--- a/src/SourceMap.cxx
+++ b/src/SourceMap.cxx
@@ -374,16 +374,17 @@ void SourceMap::computeNpredArray_sparse() {
 
   void SourceMap::setSource(const Source& src) {
     if ( m_src == &src ) {
-      if ( m_save_model && m_model.size() == 0 && m_sparseModel.size() == 0 ) {
-        if ( m_filename.size() > 0 ) {
-          readModel(m_filename);
-        } else {
-          set_energies();
-          make_model();
-          return;
-        }
+      if ( m_model.size() == 0 &&
+	   m_sparseModel.size() == 0 ) {
+	if ( m_filename.size() > 0 ) {
+	  readModel(m_filename);
+	} else {
+	  set_energies();
+	  make_model();
+	  return;
+	}
       } else {
-	    return;
+	return;
       }
     }
     m_src = &src;


### PR DESCRIPTION
Reverts fermi-lat/Likelihood#100

Turns out this fix results in a segmentation fault in certain other situations and more investigation will be needed to do the memory management better.